### PR TITLE
Remove specific server

### DIFF
--- a/letsencrypt-vesta
+++ b/letsencrypt-vesta
@@ -29,8 +29,7 @@
 #(arguments shouldn't be necessary if using /etc/letsencrypt/cli.ini)
 #The -m (mail) and -d (domain) options will be added automatically
 LETSENCRYPT_COMMAND='/usr/local/certbot/certbot-auto 
-    -t --renew-by-default --agree-tos --webroot -w /etc/letsencrypt/webroot
-    --server https://acme-v01.api.letsencrypt.org/directory'
+    -t --renew-by-default --agree-tos --webroot -w /etc/letsencrypt/webroot'
 
 #Set the path to Vesta's installation base
 #(you probably won't need to cahnge this)


### PR DESCRIPTION
Some domains were not properly getting an ssl certificate. By allowing the certbot to choose the server itself, it was able to create the certificates

The error message I was getting, was a DNS timeout looking up the CAA record, even though it existed and was ok. Once I removed the specific server from the command, the ssl creation worked great.
