### PR TITLE
Fix for removal of v-get-web-domain-value

### DIFF
--- a/letsencrypt-vesta
+++ b/letsencrypt-vesta
@@ -254,8 +254,8 @@ do
         cp /etc/letsencrypt/live/$MAINDOMAIN/chain.pem $TMPLOC/$DOMAIN.ca
 
         #Check if the site already has a cert
-        HAS_CERT=`$VESTA_PATH/bin/v-get-web-domain-value $USER $DOMAIN SSL`
-        if [[ $HAS_CERT == 'no' ]]
+        HAS_CERT=`$VESTA_PATH/bin/v-list-web-domain-ssl $USER $DOMAIN`
+        if [[ $HAS_CERT == '' ]]
         then
             #Configure SSL and install the cert
             $VESTA_PATH/bin/v-add-web-domain-ssl $USER $DOMAIN $TMPLOC


### PR DESCRIPTION
The command v-get-web-domain-value was removed in Vesta 0.9.8-17. This fixes by replacing with v-list-web-domain-ssl to perform the same function.