### PR TITLE
moving to ACMEv2 / RFC 8555.

### DIFF
--- a/letsencrypt-vesta
+++ b/letsencrypt-vesta
@@ -30,7 +30,7 @@
 #The -m (mail) and -d (domain) options will be added automatically
 LETSENCRYPT_COMMAND='/usr/local/certbot/certbot-auto 
     -t --renew-by-default --agree-tos --webroot -w /etc/letsencrypt/webroot
-    --server https://acme-v01.api.letsencrypt.org/directory'
+    --server https://acme-v02.api.letsencrypt.org/directory'
 
 #Set the path to Vesta's installation base
 #(you probably won't need to cahnge this)


### PR DESCRIPTION
ACMEv1 end of life,
moving to ACMEv2 / RFC 8555.

> Please upgrade your ACME client to a version that supports ACMEv2 / RFC 8555. See https://community.letsencrypt.org/t/end-of-life-plan-for-acmev1/88430 for details.
